### PR TITLE
Moving dependency management to conan\

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 Debug/*
+Release/*
+CMakeUserPresets.json
 *.sublime-project
 *.log
 build/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ project(clahe3d
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
-set(CMAKE_BUILD_TYPE Debug)
+if(NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE Debug)
+endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(USE_CUDA TRUE) # flag to enable and disable GPU support
@@ -40,10 +42,10 @@ else()
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules")
-find_package(ImGUI REQUIRED)
-find_package(ImGUIFileDialog REQUIRED)
-find_package(ImPlot REQUIRED)
-# find_package(Catch2 REQUIRED)
+
+find_package(ImGUI REQUIRED MODULE)
+find_package(ImGUIFileDialog REQUIRED MODULE)
+find_package(ImPlot REQUIRED MODULE)
 
 add_subdirectory(lib/)
 add_subdirectory(src/)

--- a/README.md
+++ b/README.md
@@ -27,23 +27,20 @@ cd CLAHE3D
 git submodule update --init --recursive
 ```
 
-To use the GUI or CUDA support, there are a few more dependencies to install
+The third-party C/C++ libraries (`imgui` on the docking branch, `glfw` and the
+`hdf5` C++ API) are pulled and built by [Conan](https://conan.io/).
+Two dependencies that are not on ConanCenter, `ImPlot` and `ImGuiFileDialog`, are
+fetched from git and compiled against the Conan `imgui` so their
+`ImGuiContext` layout matches the docking build.
 
-## Ubuntu
+What still has to come from your system:
 
-- Compilation tools and helpers: `git`, `cmake`, `g++`
-- GPU: `nvidia-cuda-toolkit`
-- Stuff to display things using the GUI: `libglfw3-dev`
-- Saving and reading from h5 files: `libhdf5-dev`
+- Build tooling: `git`, `cmake` (>= 3.23 for presets), `g++`, and `conan` (v2)
+- GPU support: CUDA toolkit
+- GUI support: system OpenGL and X11 runtime/dev libraries
 
-With those libraries installed it should work. A few libraries might not be matching with your OS path to them (e.g. not finding header files). The code was only tested for ArchLinux to its full extend.
-
-## ArchLinux
-
-- Compilation tools and helpers: `git`, `cmake`, `g++`
-- GPU: `cuda`
-- Stuff to display things using the GUI: `glfw-x11` or `glfw-wayland`, `glew`
-- Saving and reading from h5 files: `hdf5`
+Install Conan (once) with `pipx install conan` and, on a fresh machine, create a
+default profile with `conan profile detect`.
 
 # Installation / Compiling
 
@@ -52,12 +49,22 @@ To compile with GPU support, change the flag `USE_CUDA` in the main `CMakeLists.
 Don't forget to add the architecture required for your GPU in the `CMakeLists.txt` according to your target hardware. 
 If you want to use the [ImGui](https://github.com/ocornut/imgui) based graphical user interface (basically a simple slicing and execution interface), there is also an option for that. 
 
-Execute the following commands from the project directory to build the software:
+For a quick build, use the helper script (defaults to `Debug`):
 
 ```bash
-mkdir Debug
-cd Debug 
-cmake ..
+./build.sh            # Debug build into Debug/
+./build.sh Release    # optimised build into Release/
+```
+
+Or run the steps manually. The first lets Conan resolve/build the dependencies
+and emit a CMake toolchain into `Debug/`; the second configures and builds
+against it:
+
+```bash
+conan install . --output-folder=Debug --build=missing \
+  -s build_type=Debug -s compiler.cppstd=20
+cd Debug
+cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Debug
 make all
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Quick build helper for CLAHE3D.
+#
+#   ./build.sh            # Debug build (default)
+#   ./build.sh Debug
+#   ./build.sh Release
+#
+# It resolves dependencies with Conan, configures against the generated CMake
+# toolchain, and builds into a folder named after the build type.
+set -euo pipefail
+
+BUILD_TYPE="${1:-Debug}"
+
+if [[ "$BUILD_TYPE" != "Release" && "$BUILD_TYPE" != "Debug" ]]; then
+	echo "Usage: $0 [Release|Debug]  (got '$BUILD_TYPE')" >&2
+	exit 1
+fi
+
+# Run from the project root regardless of the caller's working directory.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+
+BUILD_DIR="$BUILD_TYPE"
+
+# 1. Resolve / build third-party dependencies and emit conan_toolchain.cmake.
+#    Pin to conancenter: all deps live there, and it avoids interactive auth
+#    prompts from other configured remotes (e.g. a private gitea).
+conan install . \
+	--output-folder="$BUILD_DIR" \
+	--build=missing \
+	-r conancenter \
+	-s build_type="$BUILD_TYPE" \
+	-s compiler.cppstd=20
+
+# 2. Configure against the Conan toolchain (path is relative to the build dir).
+cmake -S . -B "$BUILD_DIR" \
+	-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake \
+	-DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+
+# 3. Build everything.
+cmake --build "$BUILD_DIR" -j"$(nproc)"
+
+echo
+echo "Done. Binaries are in $BUILD_DIR/ (run 'ctest' from there to test)."

--- a/cmake/modules/FindImGUI.cmake
+++ b/cmake/modules/FindImGUI.cmake
@@ -1,62 +1,51 @@
-# a helper script to easily get imgui and make it available for the current
-# project
+# Provides the ImGUI_target library.
+#
+# imgui itself (docking branch) now comes from Conan (see conanfile.txt) instead
+# of FetchContent. Conan ships only the compiled core in libimgui.a; the GLFW +
+# OpenGL3 backends and the std::string helper are shipped as *source* under the
+# package's res/ folder and must be compiled into our own target here.
 
-# imgui does not have a CMakeLists.txt file
+find_package(imgui REQUIRED) # Conan CMakeDeps -> imgui::imgui (headers + libimgui.a)
+find_package(glfw3 REQUIRED) # Conan CMakeDeps -> glfw
+find_package(OpenGL REQUIRED)
 
-include(FetchContent)
+if (NOT TARGET ImGUI_target)
 
-FetchContent_Declare(
-	imgui
-	GIT_REPOSITORY https://github.com/ocornut/imgui.git
-	GIT_TAG 3912b3d9a9c1b3f17431aebafd86d2f40ee6e59c # note: this git tag is pointing to the docking branch
-	GIT_PROGRESS true
-)
-
-FetchContent_GetProperties(imgui)
-if (NOT imgui_POPULATED)
-
-	# we use the imgui implementation here depends on GLFW and OpenFL
-	find_package(GLFW REQUIRED)
-	find_package(OpenGL REQUIRED)
-  find_package(X11 REQUIRED)
-	
-  FetchContent_MakeAvailable(imgui)
+	# Locate the bindings that Conan drops under <pkg>/res. The imgui include dir
+	# is <pkg>/include, so res/ sits one level up. imgui_RES_DIRS is empty in the
+	# generated files, so we derive it from imgui_INCLUDE_DIRS (a plain path set by
+	# CMakeDeps; the target's INTERFACE_INCLUDE_DIRECTORIES is a genex and unusable
+	# for path math).
+	list(GET imgui_INCLUDE_DIRS 0 _imgui_inc)
+	get_filename_component(_imgui_root "${_imgui_inc}" DIRECTORY)
+	set(_imgui_bindings "${_imgui_root}/res/bindings")
+	set(_imgui_stdlib   "${_imgui_root}/res/misc/cpp")
 
 	add_compile_definitions(IMGUI_DEFINE_MATH_OPERATORS)
-	
+
 	add_library(ImGUI_target
-		${imgui_SOURCE_DIR}/imgui.cpp
-		${imgui_SOURCE_DIR}/imgui_draw.cpp
-		${imgui_SOURCE_DIR}/imgui_tables.cpp
-		${imgui_SOURCE_DIR}/imgui_widgets.cpp
-		${imgui_SOURCE_DIR}/backends/imgui_impl_glfw.cpp
-		${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
-		${imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp
+		${_imgui_bindings}/imgui_impl_glfw.cpp
+		${_imgui_bindings}/imgui_impl_opengl3.cpp
+		${_imgui_stdlib}/imgui_stdlib.cpp
 	)
-	
+
+	# imgui::imgui already propagates the imgui headers publicly, so consumers of
+	# ImGUI_target get imgui.h / imgui_internal.h transitively.
+	target_link_libraries(ImGUI_target
+	PUBLIC
+		imgui::imgui
+		glfw
+		OpenGL::GL
+	)
+
 	target_include_directories(ImGUI_target
 	PUBLIC
-		
-	PRIVATE
-		${imgui_SOURCE_DIR}
-		${imgui_SOURCE_DIR}/backends
-		${glfw_SOURCE_DIR}/include
+		${_imgui_bindings}
+		${_imgui_stdlib}
 	)
-
-	# glfw3_LIBRARIES is empty
-	target_link_libraries(ImGUI_target 
-	PRIVATE
-		${GLFW_LIBRARIES}
-		${OPENGL_LIBRARIES}
-    ${X11_LIBRARIES}
-	)
-
-	set(ImGUI_INCLUDE_DIR
-		${imgui_SOURCE_DIR}
-		${imgui_SOURCE_DIR}/backends
-		${imgui_SOURCE_DIR}/misc/cpp
-	)
-	set(ImGUI_FOUND TRUE)
-	set(ImGUI_LIBRARIES "ImGUI_target")
 
 endif()
+
+set(ImGUI_INCLUDE_DIR ${_imgui_bindings} ${_imgui_stdlib})
+set(ImGUI_FOUND TRUE)
+set(ImGUI_LIBRARIES "ImGUI_target")

--- a/cmake/modules/FindImGUIFileDialog.cmake
+++ b/cmake/modules/FindImGUIFileDialog.cmake
@@ -1,6 +1,9 @@
+# ImGuiFileDialog is not on ConanCenter, so it stays on FetchContent. It only needs
+# imgui.h on the include path, which ImGUI_target (Conan docking imgui) provides
+# transitively.
 include(FetchContent)
 
-find_package(ImGUI REQUIRED)
+find_package(ImGUI REQUIRED MODULE) # our module, not Conan's imgui-config
 
 FetchContent_Declare(
   ImGuiFileDialog
@@ -8,17 +11,19 @@ FetchContent_Declare(
   GIT_TAG ee77f190861193a995435c388682f1512f6fd29a
 )
 FetchContent_GetProperties(ImGuiFileDialog)
-if (NOT ImGuiFileDialog_POPULATED)
+if (NOT imguifiledialog_POPULATED)
   FetchContent_MakeAvailable(ImGuiFileDialog)
+endif()
+
+if (NOT TARGET ImGuiFileDialog_target)
   add_library(ImGuiFileDialog_target
     ${imguifiledialog_SOURCE_DIR}/ImGuiFileDialog.cpp
-    )
+  )
 
-  target_link_libraries(ImGuiFileDialog_target PUBLIC 
+  target_link_libraries(ImGuiFileDialog_target PUBLIC
     ${ImGUI_LIBRARIES})
-	
+
   target_include_directories(ImGuiFileDialog_target PUBLIC
-    ${imgui_SOURCE_DIR}
     ${imguifiledialog_SOURCE_DIR}
   )
 endif()

--- a/cmake/modules/FindImPlot.cmake
+++ b/cmake/modules/FindImPlot.cmake
@@ -1,6 +1,10 @@
+# ImPlot is kept on FetchContent (compiled from source) on purpose: ConanCenter's
+# prebuilt implot is built against the non-docking imgui and would ABI-mismatch our
+# docking imgui at runtime. Compiling it here against ImGUI_target (the Conan
+# docking imgui) keeps ImGuiContext layout consistent.
 include(FetchContent)
 
-find_package(ImGUI)
+find_package(ImGUI REQUIRED MODULE) # our module, not Conan's imgui-config
 
 FetchContent_Declare(
   ImPlot
@@ -8,19 +12,21 @@ FetchContent_Declare(
   GIT_TAG v0.17
 )
 FetchContent_GetProperties(ImPlot)
-if (NOT ImPlot_POPULATED)
+if (NOT implot_POPULATED)
   FetchContent_MakeAvailable(ImPlot)
+endif()
+
+if (NOT TARGET ImPlot_target)
   add_library(ImPlot_target
     ${implot_SOURCE_DIR}/implot.cpp
     ${implot_SOURCE_DIR}/implot_items.cpp
+  )
 
-    )
-
-  target_link_libraries(ImPlot_target PUBLIC 
+  # ImGUI_target propagates the Conan imgui include dir, so implot.cpp finds imgui.h
+  target_link_libraries(ImPlot_target PUBLIC
     ${ImGUI_LIBRARIES})
-	
+
   target_include_directories(ImPlot_target PUBLIC
-    ${imgui_SOURCE_DIR}
     ${implot_SOURCE_DIR}
   )
 endif()

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,11 @@
+[requires]
+imgui/1.91.8-docking
+glfw/3.4
+hdf5/1.14.3
+
+[options]
+hdf5/*:enable_cxx=True
+
+[generators]
+CMakeDeps
+CMakeToolchain

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,7 +84,10 @@ target_link_libraries(Volproc PUBLIC
 	Histeq
 	Histogram
 	Normalizer
-	Log)
+	Log
+	# volproc.h includes volume.h; link Volume so the HDF5 include path (now coming
+	# from Conan's hdf5::hdf5_cpp instead of a global /usr/include) propagates here.
+	Volume)
 
 add_library(Lexer lexer.cpp)
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -511,10 +511,10 @@ void gui::SlicerWindow() {
       ImImagesc(mySlice.get_plane(1), sizeArray.x, sizeArray.z, &sliceY, rawMap);
       ImImagesc(mySlice.get_plane(2), sizeArray.x, sizeArray.y, &sliceZ, rawMap);
 
-      ImGui::Image((void*)(intptr_t)sliceY, ImVec2(xLength, zLength));
+      ImGui::Image((ImTextureID)(intptr_t)sliceY, ImVec2(xLength, zLength));
       ImGui::SameLine();
-      ImGui::Image((void*)(intptr_t)sliceX, ImVec2(yLength, zLength));
-      ImGui::Image((void*)(intptr_t)sliceZ, ImVec2(xLength, yLength));
+      ImGui::Image((ImTextureID)(intptr_t)sliceX, ImVec2(yLength, zLength));
+      ImGui::Image((ImTextureID)(intptr_t)sliceZ, ImVec2(xLength, yLength));
 
       ImGui::Columns(2);
       ImGui::SliderFloat("Min Val Raw",
@@ -538,10 +538,10 @@ void gui::SlicerWindow() {
       ImImagesc(mySlice.get_plane(1), sizeArray.x, sizeArray.z, &sliceY, procMap);
       ImImagesc(mySlice.get_plane(2), sizeArray.x, sizeArray.y, &sliceZ, procMap);
 
-      ImGui::Image((void*)(intptr_t)sliceY, ImVec2(xLength, zLength));
+      ImGui::Image((ImTextureID)(intptr_t)sliceY, ImVec2(xLength, zLength));
       ImGui::SameLine();
-      ImGui::Image((void*)(intptr_t)sliceX, ImVec2(yLength, zLength));
-      ImGui::Image((void*)(intptr_t)sliceZ, ImVec2(xLength, yLength));
+      ImGui::Image((ImTextureID)(intptr_t)sliceX, ImVec2(yLength, zLength));
+      ImGui::Image((ImTextureID)(intptr_t)sliceZ, ImVec2(xLength, yLength));
 
       ImGui::Columns(2);
       ImGui::SliderFloat("Min Val Proc",


### PR DESCRIPTION
Since the dependency management with git submodules is a bit unstable and relying on system dependencies such as HDF5 leads to lot's of trouble, I moved some large dependencies now to conan.